### PR TITLE
Add useStdErr option to call mstest with /usestderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ msTest.runTests({
 * *string* **runConfig:** Path to a run configuration file
 * *string* **resultsFile:** Where to save the results
 * *bool* **debugLog:** (Default: false) If true, will print out simple debug messages to stdout
+* *bool* **useStdErr:** (Default: false) If true, mstest will output its error messages to stderr instead of stdout, which can be caught and handled with the `options.error` callback of `runTests()`
 * *object* **details:** Each key that is set to true will be treated as an additional detail. Keys are converted to lowercase when processing. See [Microsoft's MSTest.exe Command-Line Options][1] for a list of any valid details. Below is listed some examples
     * *bool* **duration**
     * *bool* **errorMessage/errormessage**

--- a/main.js
+++ b/main.js
@@ -59,6 +59,7 @@ var MSTest = function() {
 	};
 	
 	this.debugLog = false;
+	this.useStdErr = false;
 };
 
 /**
@@ -297,6 +298,11 @@ MSTest.prototype.runTests = function(options) {
 	// Save the results somewhere special
 	if (this.resultsFile) {
 		msTestArgs.push('/resultsfile:"' + this.resultsFile + '"');
+	}
+
+	// Use standard error to ouput error information that may occur attempting to run the test
+	if (this.useStdErr) {
+		msTestArgs.push('/usestderr');
 	}
 
 	// Add all extra details

--- a/parser.js
+++ b/parser.js
@@ -136,7 +136,7 @@ var Parser = function(exePath, args, workingDir, detailsMap) {
         }
     });
     child.stderr.on('data', function(err) {
-        self.emit('error', err);
+        self.emit('error', err.toString());
     });
     child.on('close', function() {
         self.emit('done', self.results, self.passedTests, self.failedTests);


### PR DESCRIPTION
I've added an option to node-mstest to call mstest with the /usestderr argument. This causes mstest to report its errors (including failing tests but also failure to run the tests due to the resultsFile already existing) to stderr instead of stdout. 

This allows one to use the error callback of runTests to e.g., fail the build, and makes it easier to capture and display error messages. 

Please review. Thanks!
